### PR TITLE
簡易的にファイルを返す

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -47,6 +47,8 @@
       <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/INT_ALIGN_ENUM_INITIALIZERS/@EntryValue" value="true" type="bool" />
       <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/EnableClangFormatSupport/@EntryValue" value="true" type="bool" />
       <option name="/Default/CodeStyle/Naming/CppNaming/Rules/=Enumerators/@EntryIndexedValue" value="&lt;NamingElement Priority=&quot;14&quot;&gt;&lt;Descriptor Static=&quot;Indeterminate&quot; Constexpr=&quot;Indeterminate&quot; Const=&quot;Indeterminate&quot; Volatile=&quot;Indeterminate&quot; Accessibility=&quot;NOT_APPLICABLE&quot;&gt;&lt;type Name=&quot;scoped enumerator&quot; /&gt;&lt;type Name=&quot;unscoped enumerator&quot; /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect=&quot;True&quot; WarnAboutPrefixesAndSuffixes=&quot;False&quot; Prefix=&quot;k&quot; Suffix=&quot;&quot; Style=&quot;AaBb&quot; /&gt;&lt;/NamingElement&gt;" type="string" />
+      <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/ExecutableToUse/@EntryValue" value="Custom" type="string" />
+      <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/ExternalClangFormatPath/@EntryValue" value="/usr/bin/clang-format" type="string" />
     </RiderCodeStyleSettings>
     <clangFormatSettings>
       <option name="ENABLED" value="true" />

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -286,6 +286,8 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=IdentifierTypo/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
+    <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/ExecutableToUse/@EntryValue" value="Custom" type="string" />
+    <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/ExternalClangFormatPath/@EntryValue" value="/usr/bin/clang-format" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppSmartPointerVsMakeFunction/@EntryIndexRemoved" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppCStyleCast/@EntryIndexRemoved" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppFunctionalStyleCast/@EntryIndexRemoved" />

--- a/.idea/forwardedPorts.xml
+++ b/.idea/forwardedPorts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PortForwardingSettings">
+    <ports>
+      <entry key="8080">
+        <ForwardedPortInfo>
+          <option name="hostPort" value="8080" />
+          <option name="readOnly" value="false" />
+        </ForwardedPortInfo>
+      </entry>
+    </ports>
+  </component>
+</project>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,8 @@ add_library(webserv_lib STATIC
         lib/http/response/response.hpp
         lib/core/handler/write_response_handler.cpp
         lib/core/handler/write_response_handler.hpp
+        lib/http/response/response_builder.cpp
+        lib/http/response/response_builder.hpp
 )
 # lib/ を include path に追加
 # PUBLIC にすると、依存するターゲットにも反映される

--- a/src/lib/core/handler/read_request_handler.cpp
+++ b/src/lib/core/handler/read_request_handler.cpp
@@ -2,9 +2,49 @@
 #include "write_response_handler.hpp"
 #include "core/action.hpp"
 #include "http/response/response.hpp"
+#include "http/response/response_builder.hpp"
 #include "utils/logger.hpp"
 #include "utils/io/reader.hpp"
 #include "utils/types/try.hpp"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+// TODO: config を元に適切な path に解決する
+// 今はカレントディレクトリからの相対パスとして扱う
+Result<std::string, error::AppError> getPath(const http::Request &req) {
+    LOG_DEBUGF("request target: %s", req.getRequestTarget().c_str());
+
+    const std::string path = req.getRequestTarget().substr(1);
+    if (path.empty()) {
+        LOG_DEBUGF("invalid request target: %s", req.getRequestTarget().c_str());
+        return Err(error::kUnknown);
+    }
+    return Ok(path);
+}
+
+// andThen で使いたいので、ref ではなく値を受け取る
+// ReSharper disable once CppPassValueParameterByConstReference
+Result<int, error::AppError> openFile(const std::string path) { // NOLINT(*-unnecessary-value-param)
+    const int fd = open(path.c_str(), O_RDONLY);
+    if (fd == -1) {
+        LOG_DEBUGF("failed to open file: %s", path.c_str());
+        return Err(error::kUnknown);
+    }
+    return Ok(fd);
+}
+
+Result<std::string, error::AppError> readFile(const int rawFd) {
+    AutoFd fd(rawFd);
+    io::FdReader fdReader(fd);
+    bufio::Reader bufReader(fdReader);
+    return Ok(TRY(bufReader.readAll()));
+}
+
+// ReSharper disable once CppPassValueParameterByConstReference
+http::Response toResponse(const std::string fileContent) { // NOLINT(*-unnecessary-value-param)
+    return http::ResponseBuilder().text(fileContent).build();
+}
 
 ReadRequestHandler::ReadRequestHandler(bufio::Reader &reader) : reqReader_(reader) {}
 
@@ -16,20 +56,17 @@ IEventHandler::InvokeResult ReadRequestHandler::invoke(const Context &ctx) {
 
     LOG_DEBUGF("HTTP request parsed");
 
-    // 今は同じ body をそのまま返す
-    http::Headers headers;
-    headers.insert(std::make_pair("Content-Length", utils::toString(req.getBody().size())));
-    headers.insert(std::make_pair("Content-Type", "text/plain"));
-    const http::Response res(http::kStatusOk, "HTTP/1.1", headers, req.getBody());
+    // TODO: すべてのエラーが 404 とは限らない. 適切なレスポンスを返すようにする
+    // TODO: readFile が kWouldBlock を返すと、読み取った req が失われる
+    const http::Response res = getPath(req)
+                                   .andThen(openFile)
+                                   .andThen(readFile)
+                                   .map(toResponse)
+                                   .unwrapOr(http::ResponseBuilder().text("not found", http::kStatusNotFound).build());
 
     std::vector<IAction *> actions;
     actions.push_back(new RegisterEventAction(Event(ctx.getEvent().getFd(), Event::kWrite)));
     actions.push_back(new RegisterEventHandlerAction(ctx.getConnection().unwrap(), new WriteResponseHandler(res)));
-    /**
-     * クライアントはこれ以上イベントを起こさない可能性がある
-     * 続きの handler が実行されるように、擬似的にイベントを通知する
-     */
-    actions.push_back(new TriggerPseudoEventAction(ctx.getEvent()));
 
     return Ok(actions);
 }

--- a/src/lib/http/response/response_builder.cpp
+++ b/src/lib/http/response/response_builder.cpp
@@ -1,0 +1,47 @@
+#include "response_builder.hpp"
+#include "utils/string.hpp"
+
+namespace http {
+    ResponseBuilder::ResponseBuilder() : status_(kStatusOk), httpVersion_("HTTP/1.1"), body_(None) {}
+
+    ResponseBuilder::~ResponseBuilder() {}
+
+    ResponseBuilder &ResponseBuilder::status(const HttpStatusCode status) {
+        status_ = status;
+        return *this;
+    }
+
+    ResponseBuilder &ResponseBuilder::header(const std::string &name, const std::string &value) {
+        headers_[name] = value;
+        return *this;
+    }
+
+    ResponseBuilder &ResponseBuilder::text(const std::string &body, const HttpStatusCode status) {
+        body_ = Some(body);
+        this->status(status);
+        this->header("Content-Type", "text/plain; charset=UTF-8");
+        this->header("Content-Length", utils::toString(body.size()));
+        return *this;
+    }
+
+    ResponseBuilder &ResponseBuilder::html(const std::string &body, const HttpStatusCode status) {
+        body_ = Some(body);
+        this->status(status);
+        this->header("Content-Type", "text/html; charset=UTF-8");
+        this->header("Content-Length", utils::toString(body.size()));
+        return *this;
+    }
+
+    ResponseBuilder &ResponseBuilder::redirect(const std::string &location, const HttpStatusCode status) {
+        this->status(status);
+        this->header("Location", location);
+        return *this;
+    }
+
+    Response ResponseBuilder::build() {
+        if (body_.isNone()) {
+            this->text("");
+        }
+        return Response(status_, httpVersion_, headers_, body_.unwrap());
+    }
+}

--- a/src/lib/http/response/response_builder.hpp
+++ b/src/lib/http/response/response_builder.hpp
@@ -1,0 +1,36 @@
+#ifndef SRC_LIB_HTTP_RESPONSE_REQUEST_BUILDER_HPP
+#define SRC_LIB_HTTP_RESPONSE_REQUEST_BUILDER_HPP
+
+#include "response.hpp"
+#include "http/header.hpp"
+#include "http/status.hpp"
+#include "utils/types/option.hpp"
+
+namespace http {
+    // TODO: テスト書く
+    class ResponseBuilder {
+    public:
+        ResponseBuilder();
+        ~ResponseBuilder();
+
+        // HTTP version は今のところ固定
+
+        ResponseBuilder &status(HttpStatusCode status);
+        ResponseBuilder &header(const std::string &name, const std::string &value);
+
+        // Content-Type, Content-Length などの必要な header を自動で付与
+        ResponseBuilder &text(const std::string &body, HttpStatusCode status = kStatusOk);
+        ResponseBuilder &html(const std::string &body, HttpStatusCode status = kStatusOk);
+        ResponseBuilder &redirect(const std::string &location, HttpStatusCode status = kStatusFound);
+
+        Response build();
+
+    private:
+        HttpStatusCode status_;
+        std::string httpVersion_;
+        Headers headers_;
+        Option<std::string> body_;
+    };
+}
+
+#endif

--- a/src/lib/utils/types/try.hpp
+++ b/src/lib/utils/types/try.hpp
@@ -14,12 +14,13 @@ types::None tryDefault(const Option<T> &) {
     return None;
 }
 
-/**
- * NOTE: TRY, TRY_OR の expr は副作用を起こしてはいけない
- * 展開によって複数回評価されてしまう
- * (副作用があっても冪等ならOK)
- */
-#define TRY(expr) TRY_OR(expr, tryDefault(expr))
+// typeof(expr) は式を評価しないので、全体として一回だけ expr が評価される
+#define TRY(expr)                                                                \
+    ({                                                                           \
+        typeof(expr) e = (expr); /* NOLINT(*-unnecessary-copy-initialization) */ \
+        if (!(e).canUnwrap()) return tryDefault(e);                              \
+        (e).unwrap();                                                            \
+    })
 
 #define TRY_OR(expr, defaultValue)                                               \
     ({                                                                           \


### PR DESCRIPTION
プロセスからの相対パスでファイルを探し、`text/plain` として返す。
設計度外視