### PR TITLE
Event::kError を追加

### DIFF
--- a/src/lib/core/server.cpp
+++ b/src/lib/core/server.cpp
@@ -27,6 +27,11 @@ void Server::start() {
             const Event &ev = events[i];
             LOG_DEBUGF("event arrived for fd %d (flags: %x)", ev.getFd(), ev.getTypeFlags());
 
+            if (ev.getTypeFlags() & Event::kError) {
+                this->onErrorEvent(ev);
+                continue;
+            }
+
             Option<Ref<IEventHandler> > handler = state_.getEventHandlerRepository().get(ev.getFd());
             if (handler.isNone()) {
                 LOG_DEBUGF("event handler for fd %d is not registered", ev.getFd());
@@ -47,6 +52,7 @@ void Server::start() {
 
 void Server::onHandlerError(const Context &ctx, const error::AppError err) {
     // kIOWouldBlock はリトライするので無視
+    // TODO: IOError は無視して、onErrorEvent で cleanup するようになる?
     if (err == error::kIOWouldBlock) {
         return;
     }
@@ -60,6 +66,23 @@ void Server::onHandlerError(const Context &ctx, const error::AppError err) {
         state_.getEventNotifier().unregisterEvent(ev);
         state_.getEventHandlerRepository().remove(ev.getFd());
         state_.getConnectionRepository().remove(ev.getFd());
+    }
+}
+
+void Server::onErrorEvent(const Event &event) {
+    if (!(event.getTypeFlags() & Event::kError)) {
+        // kError 以外は無視
+        return;
+    }
+
+    const int fd = event.getFd();
+    LOG_WARNF("error event arrived for fd %d", fd);
+
+    // (たぶん) 継続不可なので cleanup
+    if (event.getFd() != listener_.getFd()) {
+        state_.getEventNotifier().unregisterEvent(event);
+        state_.getEventHandlerRepository().remove(fd);
+        state_.getConnectionRepository().remove(fd);
     }
 }
 

--- a/src/lib/core/server.hpp
+++ b/src/lib/core/server.hpp
@@ -21,6 +21,7 @@ private:
     ServerState state_;
 
     void onHandlerError(const Context &ctx, error::AppError err);
+    void onErrorEvent(const Event &event);
     void executeActions(std::vector<IAction *> actions);
 };
 

--- a/src/lib/event/event.hpp
+++ b/src/lib/event/event.hpp
@@ -10,6 +10,7 @@ public:
     enum EventType {
         kRead = 1,
         kWrite = 1 << 1,
+        kError = 1 << 2, // register しなくても発生する. EPOLLERR に相当
     };
 
     Event();

--- a/src/lib/event/event_notifier.cpp
+++ b/src/lib/event/event_notifier.cpp
@@ -30,7 +30,7 @@ void EpollEventNotifier::registerEvent(const Event &event) {
     const int targetFd = event.getFd();
 
     epoll_event eev = {};
-    eev.events = EpollEventNotifier::toEpollEvents(event) | EPOLLET;
+    eev.events = EpollEventNotifier::toEpollEvents(event) | EPOLLERR | EPOLLET;
     eev.data.fd = targetFd;
     const int epollOp = registeredFd_.count(targetFd) == 0 ? EPOLL_CTL_ADD : EPOLL_CTL_MOD;
     if (epoll_ctl(epollFd_, epollOp, targetFd, &eev) == -1) {
@@ -78,6 +78,9 @@ uint32_t EpollEventNotifier::toEventTypeFlags(const uint32_t epollEvents) {
     if (epollEvents & EPOLLOUT) {
         flags |= Event::kWrite;
     }
+    if (epollEvents & EPOLLERR) {
+        flags |= Event::kError;
+    }
     return flags;
 }
 
@@ -89,6 +92,9 @@ uint32_t EpollEventNotifier::toEpollEvents(const Event &event) {
     }
     if (flags & Event::kWrite) {
         events |= EPOLLOUT;
+    }
+    if (flags & Event::kError) {
+        events |= EPOLLERR;
     }
     return events;
 }


### PR DESCRIPTION
subject で read/write 後の errno の確認が禁止されているので、EAGAIN かそれ以外かの判別のために `EPOLLERR` などを受け取る必要がある。