### PR TITLE
clang-tidy のエラーを絞る

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,11 @@
 # Generated from CLion Inspection settings
 ---
-WarningsAsErrors: '*'
+WarningsAsErrors: >
+  bugprone-*,
+  cert-*,
+  performance-*,
+  readability-misleading-indentation,
+  readability-redundant-declaration
 Checks: '-*,
 bugprone-argument-comment,
 bugprone-assert-side-effect,


### PR DESCRIPTION
`config` ブランチから切り出したもの