### PR TITLE
close-on-exec と non-blocking 対応

### DIFF
--- a/src/lib/utils/fd.cpp
+++ b/src/lib/utils/fd.cpp
@@ -8,3 +8,10 @@ Result<void, error::AppError> utils::setNonBlocking(const int fd) {
     }
     return Ok();
 }
+
+Result<void, error::AppError> utils::setCloseOnExec(const int fd) {
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+        return Err(error::kUnknown);
+    }
+    return Ok();
+}

--- a/src/lib/utils/fd.hpp
+++ b/src/lib/utils/fd.hpp
@@ -6,6 +6,7 @@
 
 namespace utils {
     Result<void, error::AppError> setNonBlocking(int fd);
+    Result<void, error::AppError> setCloseOnExec(int fd);
 }
 
 #endif


### PR DESCRIPTION
関連: #70 

CGI で `lsof -p $$` して確認
```
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF                NODE NAME
bash    52009 kemizuki  cwd    DIR               1,18      672             1429114 /Users/kemizuki/Documents/42/webserv
bash    52009 kemizuki  txt    REG               1,18  1310224 1152921500312522691 /bin/bash
bash    52009 kemizuki  txt    REG               1,18    81288 1152921500312536115 /usr/share/locale/en_US.UTF-8/LC_COLLATE
bash    52009 kemizuki  txt    REG               1,18  2289328 1152921500312524573 /usr/lib/dyld
bash    52009 kemizuki    0u  unix 0x4204c0c287cb30e7      0t0                     ->0xd5abae47701b4f33
bash    52009 kemizuki    1u  unix 0x4204c0c287cb30e7      0t0                     ->0xd5abae47701b4f33
bash    52009 kemizuki    2u   CHR               16,4      0t0                1531 /dev/ttys004
bash    52009 kemizuki  255r   REG               1,18      346            29456067 /Users/kemizuki/Documents/42/webserv/example/cgi/hello.cgi
```